### PR TITLE
Allow standalone onlySelectOnFirstFocus option

### DIFF
--- a/lib/knockout.selectOnFocus.js
+++ b/lib/knockout.selectOnFocus.js
@@ -28,7 +28,7 @@
 })(function (ko) {
     function getOptions(valueAccessor) {
         var options = ko.utils.unwrapObservable(valueAccessor());
-        if (options.pattern) {
+        if (options.pattern || options.onlySelectOnFirstFocus) {
             return options;
         } else {
             return {pattern: options};


### PR DESCRIPTION
otherwise discarded by `getOptions()`